### PR TITLE
Fix/cms spinner injection token

### DIFF
--- a/projects/cms-ui-demo/src/modules/spinner-demo/spinner-demo.component.html
+++ b/projects/cms-ui-demo/src/modules/spinner-demo/spinner-demo.component.html
@@ -3,7 +3,7 @@
   <div class="col-12">
     <div class="card">
       <div class="card-body">
-        <cms-spinner [id]="spinnerOnComponentId" class="black-transparent"></cms-spinner>
+        <cms-spinner-container [id]="spinnerOnComponentId" class="black-transparent"></cms-spinner-container>
         <h5 class="card-title">Spinner on component</h5>
         <p class="card-text">Spinner can be displayed onto a component to block the inner content from being
           accessed</p>
@@ -21,7 +21,7 @@
   <div class="col-12">
     <div class="card">
       <div class="card-body">
-        <cms-spinner [id]="stackableSpinnerId" class="black-transparent"></cms-spinner>
+        <cms-spinner-container [id]="stackableSpinnerId" class="black-transparent"></cms-spinner-container>
         <h5 class="card-title">Stackable spinners</h5>
         <div class="card-text">
           <ul>
@@ -85,8 +85,8 @@
             <div [style.min-height.px]="100"
                  [style.position]="'relative'"
                  class="form-group">
-              <cms-spinner [id]="spinnerDisplay.containerId"
-                           class="black-transparent"></cms-spinner>
+              <cms-spinner-container [id]="spinnerDisplay.containerId"
+                           class="black-transparent"></cms-spinner-container>
             </div>
             <div class="form-group">
               <table class="table"
@@ -152,9 +152,9 @@
             <div [style.min-height.px]="100"
                  [style.position]="'relative'"
                  class="form-group">
-              <cms-spinner [id]="multiKindSpinnerId"
+              <cms-spinner-container [id]="multiKindSpinnerId"
                            #multiKindSpinner
-                           class="black-transparent"></cms-spinner>
+                           class="black-transparent"></cms-spinner-container>
             </div>
             <div class="form-group">
               <table class="table"

--- a/projects/cms-ui/src/constants/internal-injectors.ts
+++ b/projects/cms-ui/src/constants/internal-injectors.ts
@@ -3,6 +3,7 @@ import {InjectionToken} from '@angular/core';
 import {IValidationSummarizerModuleOptions} from '../models/interfaces/validation-summarizers/validation-summarizer-module-options.interface';
 
 // Validation summarizer option.
+// tslint:disable-next-line:max-line-length
 export const VALIDATION_SUMMARIZER_OPTION = new InjectionToken<IValidationSummarizerModuleOptions>('VALIDATION_SUMMARIZER_OPTIONS_PROVIDER');
 
 // Windows provider.

--- a/projects/cms-ui/src/models/implementations/display-spinner-request.ts
+++ b/projects/cms-ui/src/models/implementations/display-spinner-request.ts
@@ -1,4 +1,4 @@
-import {ISpinnerOptions} from '../interfaces';
+import {IDisplaySpinnerOptions} from '../interfaces';
 
 export class DisplaySpinnerRequest {
 
@@ -6,7 +6,7 @@ export class DisplaySpinnerRequest {
 
   public constructor(public containerId: string,
                      public id: string,
-                     public options?: ISpinnerOptions) {
+                     public options?: IDisplaySpinnerOptions) {
   }
 
   //#endregion

--- a/projects/cms-ui/src/models/interfaces/index.ts
+++ b/projects/cms-ui/src/models/interfaces/index.ts
@@ -2,7 +2,8 @@ export * from './banners/index';
 export * from './dialogs/index';
 export * from './validation-summarizers/index';
 
-export * from './spinner-options.interface';
 export * from './timeout-action.interface';
 export * from './validation-summarizer-settings.interface';
 
+// Spinner export
+export * from './spinners/index';

--- a/projects/cms-ui/src/models/interfaces/spinners/display-spinner-options.interface.ts
+++ b/projects/cms-ui/src/models/interfaces/spinners/display-spinner-options.interface.ts
@@ -1,6 +1,6 @@
 import {ComponentFactory} from '@angular/core';
 
-export class ISpinnerOptions {
+export class IDisplaySpinnerOptions {
 
   //#region Properties
 

--- a/projects/cms-ui/src/models/interfaces/spinners/index.ts
+++ b/projects/cms-ui/src/models/interfaces/spinners/index.ts
@@ -1,0 +1,1 @@
+export * from './display-spinner-options.interface';

--- a/projects/cms-ui/src/modules/spinner/spinner-container.component.html
+++ b/projects/cms-ui/src/modules/spinner/spinner-container.component.html
@@ -1,0 +1,1 @@
+<ng-template #content></ng-template>

--- a/projects/cms-ui/src/modules/spinner/spinner-container.component.ts
+++ b/projects/cms-ui/src/modules/spinner/spinner-container.component.ts
@@ -1,27 +1,27 @@
 import {
   AfterViewInit,
-  Component, ComponentFactoryResolver,
-  HostBinding,
-  Inject, Injector,
+  Component,
+  ComponentFactoryResolver,
+  Inject,
+  Injector,
   Input,
   OnDestroy,
   OnInit,
-  TemplateRef,
   ViewChild,
-  ViewContainerRef, ViewRef
+  ViewContainerRef
 } from '@angular/core';
 import {v4 as uuid} from 'uuid';
 import {Subject, Subscription} from 'rxjs';
 import {SPINNER_SERVICE_PROVIDER} from '../../constants/injectors';
 import {ISpinnerService} from '../../services/interfaces/spinner-service.interface';
-import {DisplaySpinnerRequest, ISpinnerOptions} from '../../models';
+import {DisplaySpinnerRequest} from '../../models';
 import {DeleteSpinnerRequest} from '../../models/implementations/delete-spinner-request';
 import {BasicSpinnerComponent} from './basic-spinner/basic-spinner.component';
 import {filter} from 'rxjs/operators';
 
 @Component({
   // tslint:disable-next-line:component-selector
-  selector: 'cms-spinner',
+  selector: 'cms-spinner-container',
   templateUrl: 'spinner-container.component.html',
   styleUrls: ['spinner-container.component.scss']
 })
@@ -51,6 +51,10 @@ export class SpinnerContainerComponent implements OnInit, AfterViewInit, OnDestr
   // Subscription to handle local visibility request.
   // tslint:disable-next-line:variable-name
   private _localVisibilityRequestHandleSubscription: Subscription | undefined;
+
+  // Area which spinner will be displayed.
+  @ViewChild('content', {read: ViewContainerRef, static: false})
+  public viewContainerRef: ViewContainerRef | undefined;
 
   //#endregion
 
@@ -89,7 +93,6 @@ export class SpinnerContainerComponent implements OnInit, AfterViewInit, OnDestr
   //#region Constructor
 
   public constructor(@Inject(SPINNER_SERVICE_PROVIDER) protected spinnerService: ISpinnerService,
-                     protected readonly viewContainerRef: ViewContainerRef,
                      protected readonly componentFactoryResolver: ComponentFactoryResolver,
                      private readonly injector: Injector) {
     this.id = uuid();
@@ -136,6 +139,11 @@ export class SpinnerContainerComponent implements OnInit, AfterViewInit, OnDestr
 
   // Handle visibility changed event.
   protected handleVisibilityChangedEvent(event: DisplaySpinnerRequest | DeleteSpinnerRequest | undefined): void {
+
+    // Invalid view container ref.
+    if (!this.viewContainerRef) {
+      return;
+    }
 
     if (event instanceof DisplaySpinnerRequest) {
       const displaySpinnerRequest = event as DisplaySpinnerRequest;
@@ -199,7 +207,7 @@ export class SpinnerContainerComponent implements OnInit, AfterViewInit, OnDestr
 
   protected displaySpinner(displaySpinnerRequest: DisplaySpinnerRequest): void {
 
-    if (!displaySpinnerRequest) {
+    if (!displaySpinnerRequest || !this.viewContainerRef) {
       return;
     }
 

--- a/projects/cms-ui/src/modules/spinner/spinner-container.module.ts
+++ b/projects/cms-ui/src/modules/spinner/spinner-container.module.ts
@@ -4,8 +4,8 @@ import {CommonModule} from '@angular/common';
 import {SPINNER_SERVICE_PROVIDER} from '../../constants/injectors';
 import {ISpinnerService} from '../../services/interfaces/spinner-service.interface';
 import {BasicSpinnerComponent} from './basic-spinner/basic-spinner.component';
-import {SpinnerService} from '../../services/implementations/spinner.service';
 import {WINDOW_PROVIDERS} from '../../services/implementations/window.service';
+import {SpinnerService} from '../../services/implementations/spinners/spinner.service';
 
 export function basicSpinnerFactory(): ISpinnerService {
   return new SpinnerService();

--- a/projects/cms-ui/src/services/implementations/index.ts
+++ b/projects/cms-ui/src/services/implementations/index.ts
@@ -2,6 +2,8 @@ export * from './banner.service';
 export * from './validation-summarizer.service';
 export * from './smart-navigator.service';
 export * from './dialog.service';
-export * from './spinner.service';
+
+// Spinner export.
+export * from './spinners/index';
 
 export * from './default-screen-code.resolver';

--- a/projects/cms-ui/src/services/implementations/spinners/index.ts
+++ b/projects/cms-ui/src/services/implementations/spinners/index.ts
@@ -1,0 +1,1 @@
+export * from './spinner.service';

--- a/projects/cms-ui/src/services/implementations/spinners/spinner.service.ts
+++ b/projects/cms-ui/src/services/implementations/spinners/spinner.service.ts
@@ -1,9 +1,9 @@
-import {ISpinnerService} from '../interfaces';
+import {ISpinnerService} from '../../interfaces';
 import {Observable, ReplaySubject, Subject} from 'rxjs';
-import {DisplaySpinnerRequest} from '../../models/implementations/display-spinner-request';
+import {DisplaySpinnerRequest} from '../../../models/implementations/display-spinner-request';
 import {v4 as uuidv4} from 'uuid';
-import {DeleteSpinnerRequest} from '../../models/implementations/delete-spinner-request';
-import {ISpinnerOptions} from '../../models';
+import {DeleteSpinnerRequest} from '../../../models/implementations/delete-spinner-request';
+import {IDisplaySpinnerOptions} from '../../../models';
 
 export class SpinnerService implements ISpinnerService {
 
@@ -33,7 +33,7 @@ export class SpinnerService implements ISpinnerService {
 
   //#region Methods
 
-  public displaySpinner(containerId: string, options?: ISpinnerOptions): string {
+  public displaySpinner(containerId: string, options?: IDisplaySpinnerOptions): string {
 
     // Initialize request id.
     const requestId = uuidv4();

--- a/projects/cms-ui/src/services/interfaces/spinner-service.interface.ts
+++ b/projects/cms-ui/src/services/interfaces/spinner-service.interface.ts
@@ -1,5 +1,5 @@
 import {Observable} from 'rxjs';
-import {ISpinnerOptions} from '../../models/interfaces/spinner-options.interface';
+import {IDisplaySpinnerOptions} from '../../models/interfaces/spinners/display-spinner-options.interface';
 import {DisplaySpinnerRequest} from '../../models';
 import {DeleteSpinnerRequest} from '../../models/implementations/delete-spinner-request';
 
@@ -8,7 +8,7 @@ export interface ISpinnerService {
   //#region Methods
 
   // Display spinner
-  displaySpinner(containerId: string, options?: ISpinnerOptions): string;
+  displaySpinner(containerId: string, options?: IDisplaySpinnerOptions): string;
 
   // Delete the last spinner request.
   deleteSpinner(containerId: string, id?: string): void;


### PR DESCRIPTION
When try to use `SpinnerModule`, the application throws an error about missing `WINDOW` injector.
This PR is for fixing that issue.